### PR TITLE
fix: Affinity flow and source measurement errors

### DIFF
--- a/parma_analytics/api/routes/feed_raw_data.py
+++ b/parma_analytics/api/routes/feed_raw_data.py
@@ -10,6 +10,7 @@ from parma_analytics.api.models.feed_raw_data import (
     ApiFeedRawDataCreateIn,
     ApiFeedRawDataCreateOut,
 )
+from parma_analytics.bl.create_company_bll import create_company_if_not_exist_bll
 from parma_analytics.db.mining.models import NormalizationSchema, RawData, RawDataIn
 from parma_analytics.db.mining.service import (
     read_normalization_schema_by_datasource,
@@ -75,7 +76,12 @@ def feed_raw_data(
         mapping_schema=latest_mapping_schema,
     )
 
-    # TODO: Write normalized_data(_) to the PROD DB
+    # Check if the module is affinity and if so,
+    # save the company name to the company table if it does not exist
+    if body.source_name == "affinity":
+        create_company_if_not_exist_bll(
+            body.raw_data["name"], body.raw_data["domain"], 1
+        )
 
     return ApiFeedRawDataCreateOut(
         return_message=return_message,

--- a/parma_analytics/api/routes/source_measurement.py
+++ b/parma_analytics/api/routes/source_measurement.py
@@ -40,11 +40,12 @@ async def create_source_measurement(
     Returns:
         The created source measurement.
     """
-    created_source_measurement_id = create_source_measurement_bll(
+    created_source_measurement = create_source_measurement_bll(
         get_engine(), source_measurement
     )
+
     return ApiSourceMeasurementCreateOut(
-        id=created_source_measurement_id,
+        id=created_source_measurement.id,
         creation_msg="Source Measurement successfully created",
     )
 

--- a/parma_analytics/bl/create_company_bll.py
+++ b/parma_analytics/bl/create_company_bll.py
@@ -1,0 +1,17 @@
+"""Business layer logic for company."""
+
+from parma_analytics.db.prod.company_query import create_company_if_not_exist
+from parma_analytics.db.prod.engine import get_session
+from parma_analytics.db.prod.models.company import Company
+
+
+def create_company_if_not_exist_bll(
+    name: str, description: str, added_by: int
+) -> Company | None:
+    """Business Logic Layer for creating Company instances based on.
+
+    name, description and added_by.
+
+    This function calls the ORM query function create_company_if_doesnt_exist.
+    """
+    return create_company_if_not_exist(get_session(), name, description, added_by)

--- a/parma_analytics/bl/mining_module_manager.py
+++ b/parma_analytics/bl/mining_module_manager.py
@@ -187,8 +187,11 @@ class MiningModuleManager:
         """Construct the payload for the given data source."""
         json_payload = None
         if data_source.source_name == "affinity":
-            # For the Affinity module, we only have  GET /companies with no body
-            pass
+            # For the Affinity module, we only have companies field in the payload
+            affinity_payload = {
+                "task_id": task_id,
+            }
+            json_payload = json.dumps(affinity_payload)
         elif data_source.source_name == "github":
             logger.warning("Github payload not implemented yet.")
             github_payload = {
@@ -246,18 +249,12 @@ class MiningModuleManager:
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {token}",
                 }
-                response = None
-                if json_payload is None:
-                    response = await client.get(
-                        invocation_endpoint, headers=headers, timeout=None
-                    )
-                else:
-                    response = await client.post(
-                        invocation_endpoint,
-                        headers=headers,
-                        content=json_payload,
-                        timeout=None,
-                    )
+                response = await client.post(
+                    invocation_endpoint,
+                    headers=headers,
+                    content=json_payload,
+                    timeout=None,
+                )
                 response.raise_for_status()
         except httpx.RequestError as exc:
             logger.error(

--- a/parma_analytics/bl/source_measurement_bll.py
+++ b/parma_analytics/bl/source_measurement_bll.py
@@ -18,7 +18,7 @@ from parma_analytics.db.prod.utils.paginate import ListPaginationResult
 def create_source_measurement_bll(
     engine: Engine,
     source_measurement: ApiSourceMeasurementCreateIn,
-) -> int:
+) -> SourceMeasurement:
     """Business logic function for creating a SourceMeasurement.
 
     Args:
@@ -28,7 +28,13 @@ def create_source_measurement_bll(
     Returns:
         The created source measurement.
     """
-    return create_source_measurement_query(engine, source_measurement)
+    source_measurement_instance = SourceMeasurement(
+        type=source_measurement.type,
+        measurement_name=source_measurement.measurement_name,
+        source_module_id=source_measurement.source_module_id,
+        parent_measurement_id=source_measurement.parent_measurement_id,
+    )
+    return create_source_measurement_query(engine, source_measurement_instance)
 
 
 def read_source_measurement_bll(

--- a/parma_analytics/db/prod/company_query.py
+++ b/parma_analytics/db/prod/company_query.py
@@ -1,0 +1,26 @@
+"""CompanyDataSourceIdentifier DB queries."""
+
+
+from sqlalchemy.orm.session import Session
+
+from parma_analytics.db.prod.models.company import Company
+
+
+def create_company_if_not_exist(
+    db_session: Session, name: str, description: str, added_by: int
+) -> Company:
+    """Add a new company to the database if it doesn't exist."""
+    with db_session as session:
+        record = session.query(Company).filter(Company.name == name).first()
+
+        if record:
+            # The company already exists, do nothing
+            return record
+        else:
+            new_company = Company(name=name, description=description, added_by=added_by)
+            session.add(new_company)
+
+            session.commit()
+
+            session.refresh(new_company)
+            return new_company

--- a/parma_analytics/db/prod/models/company.py
+++ b/parma_analytics/db/prod/models/company.py
@@ -1,0 +1,23 @@
+"""Company model."""
+import sqlalchemy as sa
+
+from parma_analytics.db.prod.engine import Base
+
+
+class Company(Base):
+    """Model for the company table in the database."""
+
+    __tablename__ = "company"
+
+    id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
+    name = sa.Column(sa.String, nullable=False)
+    description = sa.Column(sa.String, nullable=True)
+    added_by = sa.Column(sa.Integer, nullable=False)
+    created_at = sa.Column(sa.DateTime, nullable=False, default=sa.func.now())
+    modified_at = sa.Column(
+        sa.DateTime, nullable=False, default=sa.func.now(), onupdate=sa.func.now()
+    )
+
+    def __repr__(self):
+        """Return a string representation of the Company object."""
+        return f"<Company(id={self.id}, name={self.name})>"

--- a/tests/bl/test_mining_module_manager.py
+++ b/tests/bl/test_mining_module_manager.py
@@ -205,7 +205,11 @@ def test_construct_payload_github(task_id, mining_module_manager):
 def test_construct_payload_affinity(task_id, mining_module_manager):
     # Setup
     mock_data_source = DataSource(source_name="affinity")
-    expected_payload = None
+    expected_payload = json.dumps(
+        {
+            "task_id": task_id,
+        }
+    )
 
     # Run the Test
     result = mining_module_manager._construct_payload(mock_data_source, task_id)
@@ -311,27 +315,6 @@ async def test_trigger_post_success(mock_async_client_class, mining_module_manag
     # Assertions
     mock_async_client_instance.post.assert_awaited_once_with(
         invocation_endpoint, headers=ANY, content=json_payload, timeout=None
-    )
-
-
-@pytest.mark.asyncio
-@patch("httpx.AsyncClient")
-async def test_trigger_get_success(mock_async_client_class, mining_module_manager):
-    # Setup
-    mock_async_client_instance = (
-        mock_async_client_class.return_value.__aenter__.return_value
-    )
-    mock_async_client_instance.get.return_value = AsyncMock(status_code=200)
-
-    data_source_id = 1
-    invocation_endpoint = "http://test-endpoint.com/companies"
-
-    # Run the Test
-    await mining_module_manager._trigger(data_source_id, invocation_endpoint, None)
-
-    # Assertions
-    mock_async_client_instance.get.assert_awaited_once_with(
-        invocation_endpoint, headers=ANY, timeout=None
     )
 
 


### PR DESCRIPTION
# Motivation

- Sourcing initialization errors solution 
- Affinity - analytics flow implementation (create company using affinities data)

# Changes

- Inside the feed-raw-data, if the sourcing module is affinity then create company if it doesn't exist in the db.
- Fix create source-measurement errors
- Add missing task_id to send it to affinity, and also affinity endpoint is changed from get to post
  - Constructing payload will be changed later by tino

# Checklist

- [x] added myself as assignee
- [x] correct reviewers
- [x] descriptive PR title using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] description explains the motivation and details of the changes
- [x] tests cover my changes
- [x] my functions are fully typed
- [x] documentation is updated
- [x] CI is green
- [x] breaking changes are discussed with the team and documented in the PR title `!` (e.g. `feat!: Update endpoint`)
