### PR TITLE
feat: Add weekly report scheduler

### DIFF
--- a/terraform/module/scheduler.tf
+++ b/terraform/module/scheduler.tf
@@ -1,3 +1,4 @@
+# Data sourcing modules scheduler
 resource "google_cloud_scheduler_job" "schedule_job" {
   depends_on = []
   name       = "schedule-job-${var.env}"
@@ -5,6 +6,21 @@ resource "google_cloud_scheduler_job" "schedule_job" {
 
   http_target {
     uri         = "https://analytics.${var.api_subdomain}${var.base_domain}/schedule"
+    http_method = "GET"
+  }
+
+  project = var.project
+  region  = var.region
+}
+
+# Weekly reports
+resource "google_cloud_scheduler_job" "weekly_reports_schedule_job" {
+  depends_on = []
+  name       = "weekly-reports-schedule-job-${var.env}"
+  schedule   = "0 8 * * 1" # Every Monday at 8 AM
+
+  http_target {
+    uri         = "https://analytics.${var.api_subdomain}${var.base_domain}/weekly-reports"
     http_method = "GET"
   }
 


### PR DESCRIPTION
# Motivation

We need to trigger report generation weekly. We add another google cloud scheduler to generate reports which runs at Monday 8 am each week.
