### PR TITLE
fix: Adjust `company_data_source` tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from parma_analytics.db.prod.engine import get_session
+
+
+@pytest.fixture
+def session() -> Iterator[Session]:
+    with get_session() as s:
+        yield s

--- a/tests/db/test_company_data_source_query.py
+++ b/tests/db/test_company_data_source_query.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy.orm import Session
 
 from parma_analytics.db.prod.company_data_source_query import (
     CompanyDataSourceData,
@@ -15,9 +16,9 @@ from parma_analytics.db.prod.engine import get_session
 from parma_analytics.db.prod.models.company_data_source import CompanyDataSource
 
 
-# Setup test database and session
 @pytest.fixture
 def mock_db():
+    """Setup test database and session."""
     return MagicMock()
 
 
@@ -26,9 +27,9 @@ def mock_company_data_source():
     return MagicMock(spec=CompanyDataSource)
 
 
-def test_get_company_data_source():
-    # Exercise
-    result = get_company_data_source(get_session(), 1, 1)
+def test_get_company_data_source(session: Session):
+    # Test
+    result = get_company_data_source(session, 1, 1)
 
     # Verify
     if result is not None:
@@ -56,7 +57,7 @@ def test_get_all_company_data_sources_by_data_source_id(
     )
     mock_get_all_company_data_sources_by_data_source_id.return_value = [data1, data2]
 
-    # Exercise
+    # Test
     result = mock_get_all_company_data_sources_by_data_source_id()
 
     # Verify
@@ -68,23 +69,26 @@ def test_get_all_company_data_sources_by_data_source_id(
 
 
 def test_get_all_company_data_sources():
-    # Exercise
+    # Test
     result = get_all_company_data_sources(get_session())
 
     # Verify
-    assert len(result) > 0
+    assert isinstance(result, list)
 
 
 def test_create_company_data_source(mock_db):
     # Setup
+    num_before = len(get_all_company_data_sources(get_session()))
     data = CompanyDataSourceData(1, 1, True, "healthy")
 
-    # Exercise
+    # Test
     result = create_company_data_source(mock_db, data)
+    num_after = len(get_all_company_data_sources(get_session()))
 
     # Verify
     assert result.company_id == 1
     assert result.data_source_id == 1
+    assert num_after == num_before + 1
 
 
 def test_update_company_data_source(mock_db):
@@ -93,7 +97,7 @@ def test_update_company_data_source(mock_db):
     create_company_data_source(mock_db, data)
     update_data = CompanyDataSourceUpdateData(False, "unhealthy")
 
-    # Exercise
+    # Test
     result = update_company_data_source(mock_db, 1, update_data)
 
     # Verify
@@ -104,11 +108,14 @@ def test_update_company_data_source(mock_db):
 
 def test_delete_company_data_source(mock_db):
     # Setup
+    num_before = len(get_all_company_data_sources(get_session()))
     data = CompanyDataSourceData(1, 1, True, "healthy")
     create_company_data_source(mock_db, data)
 
-    # Exercise
+    # Test
     result = delete_company_data_source(mock_db, 1)
+    num_after = len(get_all_company_data_sources(get_session()))
 
     # Verify
     assert result is True
+    assert num_after == num_before - 1


### PR DESCRIPTION
# Motivation

Database layer tests didn't interface with the database because of mocking. Imho we shouldn't mock the database on the database layer.

# Changes

- use context manager for `get_engine`

# TODO

- don't mock database access in the database layer tests

# Checklist

- [ ] added myself as assignee
- [ ] correct reviewers
- [ ] descriptive PR title using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] description explains the motivation and details of the changes
- [ ] tests cover my changes
- [ ] my functions are fully typed
- [ ] documentation is updated
- [ ] CI is green
- [ ] breaking changes are discussed with the team and documented in the PR title `!` (e.g. `feat!: Update endpoint`)
