### PR TITLE
fix: Address invalid join in scheduling query

### DIFF
--- a/parma_analytics/db/prod/queries/create_pending_scheduled_tasks.sql
+++ b/parma_analytics/db/prod/queries/create_pending_scheduled_tasks.sql
@@ -11,12 +11,12 @@ WITH RECURSIVE last_runs_per_datasource (id, freq, last_schedule) AS (
             ELSE NOW()
         END          AS last_schedule
     FROM data_source AS ds
-    LEFT JOIN scheduled_task AS st ON ds.id = st.data_source_id
-    -- not on_demand scheduled
-    WHERE
-        (st.schedule_type = 'REGULAR' OR st.schedule_type IS NULL)
-        AND ds.is_active = TRUE
-
+    LEFT JOIN scheduled_task AS st
+        ON ds.id = st.data_source_id AND (
+            -- not on_demand scheduled
+            (st.schedule_type = 'REGULAR' OR st.schedule_type IS NULL)
+        )
+    WHERE ds.is_active = TRUE
     GROUP BY id, freq  -- look at data sources latest regular schedules
 ),
 


### PR DESCRIPTION
# Motivation

The left outer join didn't work as expected with the right-hand side filters in the WHERE clause. Adding them to the JOIN condition fixes the issue.

The faulty case was a data source where I deleted all `regular` scheduled tasks. The missing regular tasks excluded the data source from the recursive query.

fyi. @egekocabas 